### PR TITLE
[Enhancement] Port configuration issue #13

### DIFF
--- a/archetype-gulpfile.js
+++ b/archetype-gulpfile.js
@@ -115,9 +115,9 @@ const tasks = {
 
   "npm:prepublish": ["build-lib", "build-dist-dev", "build-dist-min"],
 
-  "server-dev": () => exec(`webpack-dev-server --port 4000 --config ${__dirname}/config/webpack/webpack.config.demo.dev.js --colors`),
+  "server-dev": () => exec(`webpack-dev-server --config ${__dirname}/config/webpack/webpack.config.demo.dev.js --colors`),
   "server-dev-iso": () => exec(`webpack-dev-server --port 2992 --config ${__dirname}/config/webpack/webpack.config.demo.dev.js --colors`),
-  "server-hot": () => exec(`webpack-dev-server --port 4000 --config ${__dirname}/config/webpack/webpack.config.demo.hot.js --colors`),
+  "server-hot": () => exec(`webpack-dev-server --config ${__dirname}/config/webpack/webpack.config.demo.hot.js --colors`),
   "server-test": () => exec(`webpack-dev-server --port 3001 --config ${__dirname}/config/webpack/webpack.config.test.js --colors`),
 
   "test-ci": ["test-frontend-ci"],


### PR DESCRIPTION
fixes: https://github.com/electrode-io/generator-electrode-component/issues/13

`WEBPACK_DEVSERVER_PORT` to provide a custom port number to start the dev/demo env's for the components.

example screenshot of starting on port `4002`

***`$ WEBPACK_DEVSERVER_PORT=4002 gulp dev`***

![screen shot 2016-10-31 at 11 09 54 am](https://cloud.githubusercontent.com/assets/360041/19865722/a4011496-9f5a-11e6-8720-ccb1b3f780ab.png)
